### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/craig/0d9c2e5a-6595-470c-9555-89b41b396da0/bae2713d-6786-4a79-97b0-43244ce38d3a/_apis/work/boardbadge/3fbba4c4-93a0-4dd0-9afa-531b99e3f82e)](https://dev.azure.com/craig/0d9c2e5a-6595-470c-9555-89b41b396da0/_boards/board/t/bae2713d-6786-4a79-97b0-43244ce38d3a/Microsoft.RequirementCategory)
 # sql-nanite
 Another SQL Script Generator for plain O/RM.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#21](https://dev.azure.com/craig/0d9c2e5a-6595-470c-9555-89b41b396da0/_workitems/edit/21). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.